### PR TITLE
Adjust required package versions

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ import os
 if not os.environ.get('READTHEDOCS') == 'True':
     requirements = [
         'oemof >= 0.2.1',
-        'pandas >= 0.17.0',
+        'pandas >= 0.21.0',
         'demandlib',
         'tables',
         'matplotlib',
@@ -15,7 +15,7 @@ if not os.environ.get('READTHEDOCS') == 'True':
         'pvlib==v0.6.1-beta',
         'geopandas',
         'requests',
-        'numpy',
+        'numpy <= 1.15.4',
         'workalendar',
         'owslib',
         'pyproj',
@@ -24,7 +24,9 @@ if not os.environ.get('READTHEDOCS') == 'True':
         'networkx',
         'dill',
         'PyQt5',
-        'cython']
+        'cython',
+        'xlrd',
+        'Rtree']
 else:
     requirements = ['oemof', 'cycler']
 


### PR DESCRIPTION
* 2 missing packages: xlrd, Rtree
* pandas: needs to be >0.21.0 as the column param "columns" in drop() which is [used in reegis](https://github.com/nesnoj/reegis/blob/a8163b2a7934f672e57acc492e1570bd635832d5/reegis/powerplants.py#L142) is not supported in versions<0.21.0,
cf. https://pandas.pydata.org/pandas-docs/stable/generated/pandas.DataFrame.drop.html
* numpy: HDF5 bug in 1.16.0 (reported today!) when using with pandas,
cf. https://github.com/numpy/numpy/issues/12791 , caused by pytables, cf. https://github.com/PyTables/PyTables/issues/719
**This should be removed as soon as the bug is fixed**